### PR TITLE
use proper semantic elements for texts

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -19,9 +19,9 @@ const IndexPage = () => {
     >
       <title>SonWan UI</title>
       <div style={{ width: 768, maxWidth: "100%" }} className="flex flex-col">
-        <div className="text-5xl font-extrabold text-center tracking-tighter mb-2">
+        <h1 className="text-5xl font-extrabold text-center tracking-tighter mb-2">
           SonWan UI
-        </div>
+        </h1>
         <div className="text-sm font-light text-center px-8 tracking-wide mb-6 max-w-lg self-center">
           <p>
             SonWan UI is a modular, component library based on figma design to
@@ -58,7 +58,7 @@ const IndexPage = () => {
               />
             </Card>
             <Card>
-              <div className="opacity-50 my-1">Recent Contacts</div>
+              <h3 className="opacity-50 my-1">Recent Contacts</h3>
               <CardItem
                 title="Samantha"
                 className="py-4"
@@ -154,9 +154,9 @@ const IndexPage = () => {
                 onSwipeFinish={() => alert("Swipe Triggered")}
               />
             </div>
-            <div className="py-4 text-sm opacity-50 w-full text-center">
+            <span className="block py-4 text-sm opacity-50 w-full text-center">
               More Component Coming Soon...
-            </div>
+            </span>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Part 2 of the series of [code review](https://www.youtube.com/watch?v=q9bO0C9QQ6o) PRs.

For accessibility reasons, it is highly recommended to use the proper semantic elements for text blocks (`<h1>`-`<h6>`, `<p>`, and `<span>`).